### PR TITLE
feat: add expires_at when useAutoRenew is set to false

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -766,7 +766,7 @@ export class OIDCClient extends EventEmitter<EventTypes>{
 
   private async onUserLogin( authObj: any ){
     const { expires_in, user, scope, access_token, id_token, refresh_token, session_state, id_token_raw } = authObj
-    const expires_at = expires_in ? expires_in + Date.now()/1_000 : undefined
+    const expires_at = Number.isFinite( expires_in ) ? expires_in + Date.now()/1_000 : undefined
     await this.authStore.set( 'auth', { expires_at, ...authObj } )
 
     this.user = user

--- a/src/client.ts
+++ b/src/client.ts
@@ -766,7 +766,8 @@ export class OIDCClient extends EventEmitter<EventTypes>{
 
   private async onUserLogin( authObj: any ){
     const { expires_in, user, scope, access_token, id_token, refresh_token, session_state, id_token_raw } = authObj
-    await this.authStore.set( 'auth', authObj )
+    const expires_at = expires_in ? expires_in + Date.now()/1_000 : undefined
+    await this.authStore.set( 'auth', { expires_at, ...authObj } )
 
     this.user = user
     this.scopes = scope?.split( ' ' );

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -185,6 +185,7 @@ export interface TokenResponse {
   access_token?: string;
   error?: string;
   error_description?: string,
+  expires_at?: number;
   expires_in?: number;
   id_token?: string;
   refresh_token?: string;


### PR DESCRIPTION
In the use case when user does not want to use auto-renew, it is handy to have the actual date of expiration to renew just in time, without the use of a timer.

This PR adds expires_at property to authStore, if expires_in exists and is a valid number.