### PR TITLE
feat: add sessionStorage to Storage options

### DIFF
--- a/src/helpers/state_manager/index.ts
+++ b/src/helpers/state_manager/index.ts
@@ -1,3 +1,3 @@
 export * from './state_store'
-export * from './local_storage'
+export * from './web_storage'
 export * from './in_memory'


### PR DESCRIPTION
Currently only memory or local storage options are available for users of this library.

A common option to store tokens is to use sessionStorage, which offers a decent security compromise, and survives to more scenarios than memoryStorage does.

This PR offers both LocalStorage and SessionStorage as options, using a generalized WebStorage parent class.